### PR TITLE
grabbing xPath in content-script and sending it to App

### DIFF
--- a/client/components/EventLogger.tsx
+++ b/client/components/EventLogger.tsx
@@ -11,6 +11,12 @@ import { inputEventListener, getRelativeXPath, RecordedEvent } from "../utils/in
  * )
  * @returns {ReactElement} A React element containing list of recorded events
  */
+
+window.addEventListener('message', (event) => {
+  const xPath = event.data.xPath;
+  console.log('in app', xPath)
+  // Display xPath in your app UI
+});
 const EventLogger: React.FC = () => {
   // Maintain state for recorded events, focused element, and initial input value
   const [events, setEvents] = useState<Array<RecordedEvent>>([]);


### PR DESCRIPTION
Grabbing relative xPath in the content script and sending it to 'app' where its console logged. 